### PR TITLE
adding delay when heading to the world screen

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,5 @@
 # if the car doesn't steer try lowering this value
-STEERING_SIMILARITY_THRESHOLD = -0.5
+STEERING_SIMILARITY_THRESHOLD = -5.0
 # Setting this to True to see the similarity value in the console to 
 # help fine tune the steering threshold value. This value should not be 
 # lower then the value that is reported when the countersteering icon is red. 

--- a/gran_turismo.py
+++ b/gran_turismo.py
@@ -223,3 +223,5 @@ while True:
         window.key_click(config.DPAD_RIGHT, 0.2)
     window.key_click(config.CROSS, 0.5)
     window.key_click(config.CROSS, 0.5)
+    time.sleep(5.0)
+


### PR DESCRIPTION
This addresses an issue where python may begin looking for the world screen before the race screen has faded to black (python will detect the GT logo in top left as if it was the world screen), resulting in transition to the 'selecting a championship' phase early and therefore breaking the cycle.

5 Seconds seems to be a good delay, it allows for ample time to fade out without adding any extra time to the cycle (PS5 takes about 6 seconds to reach the world screen).